### PR TITLE
Update tns-core-modules to 2.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "nativescript-theme-core": "1.0.2",
     "reflect-metadata": "0.1.8",
     "rxjs": "5.0.1",
-    "tns-core-modules": "2.5.0"
+    "tns-core-modules": "2.5.1"
   },
   "devDependencies": {
     "babel-traverse": "6.8.0",
@@ -40,6 +40,7 @@
     "nativescript-dev-typescript": "0.3.5",
     "tslint": "3.14.0",
     "typescript": "2.0.10",
-    "zone.js": "0.7.2"
+    "zone.js": "0.7.2",
+    "nativescript-dev-android-snapshot": "0.0.6"
   }
 }


### PR DESCRIPTION
We need to update the tns-core-modules to 2.5.1 to get the fixes for Android action bar bug.