### PR TITLE
Fix local release builds for Android

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,6 @@
     "tslint": "3.14.0",
     "typescript": "2.0.10",
     "zone.js": "0.7.2",
-    "nativescript-dev-android-snapshot": "0.0.7"
+    "nativescript-dev-android-snapshot": "0.0.8"
   }
 }


### PR DESCRIPTION
The local release builds for Android in Fusion do not produce the same result as {N} CLI. The problem is in the `nativescript-dev-android-snapshot` plugin, which relies on a specific object, that's populated only when using CLI from the command line.
The plugin is fixed in it's latest version, so use it in the template. This way the builds will work in the same way in Fusion.

Fixes http://teampulse.telerik.com/view#item/330327